### PR TITLE
[features] Leader election + `KUBERNETES_NAMESPACE` environment variable

### DIFF
--- a/wp-operator.py
+++ b/wp-operator.py
@@ -665,8 +665,8 @@ class NamespaceFromEnv:
             return os.environ['KUBERNETES_NAMESPACE']
         else:
             # Poor man's `click`
-            for i in range(1, len(sys.argv) - 1):
-                if sys.argv[i] in ('--namespace', '-n'):
+            for i in range(1, len(sys.argv)):
+                if (i < len(sys.argv)) and (sys.argv[i] in ('--namespace', '-n')):
                     return sys.argv[i + 1]
                 else:
                     matched = re.match('--namespace=(.*)$', sys.argv[i])

--- a/wp-operator.py
+++ b/wp-operator.py
@@ -9,6 +9,9 @@ import logging
 from kubernetes import client, config
 from kubernetes.dynamic import DynamicClient
 from kubernetes.client.exceptions import ApiException
+from kubernetes.leaderelection import leaderelection
+from kubernetes.leaderelection.resourcelock.configmaplock import ConfigMapLock
+from kubernetes.leaderelection import electionconfig
 import base64
 import os
 import subprocess
@@ -17,7 +20,9 @@ import yaml
 import re
 from datetime import datetime, timezone
 import time
+
 import secrets
+import uuid
 
 class Config:
     secret_name = "nginx-conf-site-tree"
@@ -86,8 +91,37 @@ class Config:
 def on_delete_wordpresssite(spec, name, namespace, patch, **kwargs):
     WordPressSiteOperator(name, namespace, patch).delete_site(spec)
 
+class NamespaceLeaderElection:
+    def __init__(self, namespace):
+        self.lock_namespace = namespace
+        self.lock_name = f"wpn-operator-lock-{namespace}"
+        self.candidate_id = uuid.uuid4()
+        self.config = electionconfig.Config(
+            ConfigMapLock(
+                self.lock_name, 
+                self.lock_namespace, 
+                self.candidate_id
+            ),
+            lease_duration = 17,
+            renew_deadline = 15,
+            retry_period = 5,
+            onstarted_leading = self.on_started_leading,
+            onstopped_leading = self.on_stopped_leading
+        )
+
+    def on_started_leading(self):
+        print(f"Instance {self.candidate_id} is the leader for namespace {self.lock_namespace}.")
+
+    def on_stopped_leading(self):
+        print(f"Instance {self.candidate_id} stopped being the leader for namespace {self.lock_namespace}.")
+
 @kopf.on.startup()
 def on_kopf_startup (**kwargs):
+    config.load_kube_config()
+    # TODO: Retrieve the current namespace (how to do this!!?)
+    namespace = 'wordpress-test'
+    leader_election = NamespaceLeaderElection(namespace)
+    leaderelection.LeaderElection(leader_election.config).run()
     WordPressCRDOperator.ensure_wp_crd_exists()
 
 @kopf.on.create('wordpresssites')

--- a/wp-operator.py
+++ b/wp-operator.py
@@ -91,37 +91,8 @@ class Config:
 def on_delete_wordpresssite(spec, name, namespace, patch, **kwargs):
     WordPressSiteOperator(name, namespace, patch).delete_site(spec)
 
-class NamespaceLeaderElection:
-    def __init__(self, namespace):
-        self.lock_namespace = namespace
-        self.lock_name = f"wpn-operator-lock-{namespace}"
-        self.candidate_id = uuid.uuid4()
-        self.config = electionconfig.Config(
-            ConfigMapLock(
-                self.lock_name, 
-                self.lock_namespace, 
-                self.candidate_id
-            ),
-            lease_duration = 17,
-            renew_deadline = 15,
-            retry_period = 5,
-            onstarted_leading = self.on_started_leading,
-            onstopped_leading = self.on_stopped_leading
-        )
-
-    def on_started_leading(self):
-        print(f"Instance {self.candidate_id} is the leader for namespace {self.lock_namespace}.")
-
-    def on_stopped_leading(self):
-        print(f"Instance {self.candidate_id} stopped being the leader for namespace {self.lock_namespace}.")
-
 @kopf.on.startup()
 def on_kopf_startup (**kwargs):
-    config.load_kube_config()
-    # TODO: Retrieve the current namespace (how to do this!!?)
-    namespace = 'wordpress-test'
-    leader_election = NamespaceLeaderElection(namespace)
-    leaderelection.LeaderElection(leader_election.config).run()
     WordPressCRDOperator.ensure_wp_crd_exists()
 
 @kopf.on.create('wordpresssites')
@@ -686,6 +657,41 @@ class WordPressCRDOperator:
       return False
 
 
+class NamespaceLeaderElection:
+    def __init__(self, namespace):
+        self.lock_namespace = namespace
+        self.lock_name = f"wpn-operator-lock-{namespace}"
+        self.candidate_id = uuid.uuid4()
+        self.config = electionconfig.Config(
+            ConfigMapLock(
+                self.lock_name, 
+                self.lock_namespace, 
+                self.candidate_id
+            ),
+            lease_duration = 17,
+            renew_deadline = 15,
+            retry_period = 5,
+            onstarted_leading = self.start_kopf,
+            onstopped_leading = self.exit_immediately
+        )
+
+    def start_kopf(self):
+        print(f"Instance {self.candidate_id} is the leader for namespace {self.lock_namespace}.")
+        sys.exit(kopf.cli.main())
+
+    def exit_immediately(self):
+        print(f"Instance {self.candidate_id} stopped being the leader for namespace {self.lock_namespace}.")
+        sys.exit(0)
+
+    @classmethod
+    def go (cls):
+        config.load_kube_config()
+        # TODO: Retrieve the current namespace (how to do this!!?)
+        namespace = 'wordpress-test'
+        leader_election = cls(namespace)
+        leaderelection.LeaderElection(leader_election.config).run()
+
+
 if __name__ == '__main__':
     Config.load_from_command_line()
-    sys.exit(kopf.cli.main())
+    NamespaceLeaderElection.go()

--- a/wp-operator.py
+++ b/wp-operator.py
@@ -658,15 +658,52 @@ class WordPressCRDOperator:
       return False
 
 
+class NamespaceFromEnv:
+    @classmethod
+    def guess (cls):
+        if 'KUBERNETES_NAMESPACE' in os.environ:
+            return os.environ['KUBERNETES_NAMESPACE']
+        else:
+            # Poor man's `click`
+            for i in range(1, len(sys.argv) - 1):
+                if sys.argv[i] in ('--namespace', '-n'):
+                    return sys.argv[i + 1]
+                else:
+                    matched = re.match('--namespace=(.*)$', sys.argv[i])
+                    if matched:
+                        return matched[1]
+
+        raise ValueError('This is a namespaced-*only* operator. Please set KUBERNETES_NAMESPACE or pass --namespace.')
+
+    guessed = None
+    @classmethod
+    def get (cls):
+        if cls.guessed is None:
+            cls.guessed = cls.guess()
+
+        return cls.guessed
+
+    @classmethod
+    def setup (cls):
+        namespace = cls.get()
+        logging.info(f'Running in namespace {namespace}')
+        os.environ['KUBERNETES_NAMESPACE'] = namespace
+        try:
+            dashdash_position = sys.argv.index('--')
+        except ValueError:
+            dashdash_position = len(sys.argv)
+        sys.argv[dashdash_position:dashdash_position] = [f'--namespace={namespace}']
+
+
 class NamespaceLeaderElection:
-    def __init__(self, namespace):
-        self.lock_namespace = namespace
-        self.lock_name = f"wpn-operator-lock-{namespace}"
+    def __init__(self):
+        self.lock_namespace = NamespaceFromEnv.get()
+        self.lock_name = f"wpn-operator-lock"
         self.candidate_id = uuid.uuid4()
         self.config = electionconfig.Config(
             ConfigMapLock(
-                self.lock_name, 
-                self.lock_namespace, 
+                self.lock_name,
+                self.lock_namespace,
                 self.candidate_id
             ),
             lease_duration = 17,
@@ -690,9 +727,7 @@ class NamespaceLeaderElection:
     @classmethod
     def go (cls):
         config.load_kube_config()
-        # TODO: Retrieve the current namespace (how to do this!!?)
-        namespace = 'wordpress-test'
-        leader_election = cls(namespace)
+        leader_election = cls()
 
         class QuietLeaderElection(leaderelection.LeaderElection):
             def update_lock(self, leader_election_record):
@@ -701,11 +736,11 @@ class NamespaceLeaderElection:
                 update_status = self.election_config.lock.update(self.election_config.lock.name,
                                                                  self.election_config.lock.namespace,
                                                                  leader_election_record)
-        
+
                 if update_status is False:
                     logging.info("{} failed to acquire lease".format(leader_election_record.holder_identity))
                     return False
-        
+
                 self.observed_record = leader_election_record
                 self.observed_time_milliseconds = int(time.time() * 1000)
                 return True
@@ -715,4 +750,5 @@ class NamespaceLeaderElection:
 
 if __name__ == '__main__':
     Config.load_from_command_line()
+    NamespaceFromEnv.setup()
     NamespaceLeaderElection.go()

--- a/wp-operator.py
+++ b/wp-operator.py
@@ -19,6 +19,7 @@ import sys
 import yaml
 import re
 from datetime import datetime, timezone
+import threading
 import time
 
 import secrets
@@ -671,13 +672,16 @@ class NamespaceLeaderElection:
             lease_duration = 17,
             renew_deadline = 15,
             retry_period = 5,
-            onstarted_leading = self.start_kopf,
+            onstarted_leading = self.start_kopf_in_thread,
             onstopped_leading = self.exit_immediately
         )
 
-    def start_kopf(self):
+    def start_kopf_in_thread(self):
         print(f"Instance {self.candidate_id} is the leader for namespace {self.lock_namespace}.")
-        sys.exit(kopf.cli.main())
+        def do_run_kopf ():
+            sys.exit(kopf.cli.main())
+
+        threading.Thread(target=do_run_kopf).run()
 
     def exit_immediately(self):
         print(f"Instance {self.candidate_id} stopped being the leader for namespace {self.lock_namespace}.")

--- a/wp-operator.py
+++ b/wp-operator.py
@@ -693,7 +693,24 @@ class NamespaceLeaderElection:
         # TODO: Retrieve the current namespace (how to do this!!?)
         namespace = 'wordpress-test'
         leader_election = cls(namespace)
-        leaderelection.LeaderElection(leader_election.config).run()
+
+        class QuietLeaderElection(leaderelection.LeaderElection):
+            def update_lock(self, leader_election_record):
+                """(Copied and) overridden to silence the “has successfully acquired lease” message every 5 seconds."""
+                # Update object with latest election record
+                update_status = self.election_config.lock.update(self.election_config.lock.name,
+                                                                 self.election_config.lock.namespace,
+                                                                 leader_election_record)
+        
+                if update_status is False:
+                    logging.info("{} failed to acquire lease".format(leader_election_record.holder_identity))
+                    return False
+        
+                self.observed_record = leader_election_record
+                self.observed_time_milliseconds = int(time.time() * 1000)
+                return True
+
+        QuietLeaderElection(leader_election.config).run()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Pair-programmed with @Azecko, @ponsfrilus and @obieler.

- Elect a leader using `kubernetes.leaderelection` and a ConfigMap (given that we cannot [yet](https://github.com/kubernetes-client/python/issues/1877) use the proper Lease objects)
- This effectively forces the operator into single-namespace mode, since ConfigMaps (and Leases) are namespaced objects. Ensure that the user stipulated a namespace, either through the `KUBERNETES_NAMESPACE` environment variable (which has priority) or through one of the `--namespace=foo`, `-namespace foo` or `-n foo` command-line flag combos
