### PR TITLE
[fix] Ensure that plugins default to an empty array

### DIFF
--- a/WordPressSite-crd.yaml
+++ b/WordPressSite-crd.yaml
@@ -88,6 +88,7 @@ spec:
                     items:
                       type: string
                       pattern: ^[\w -_.]{3,}$
+                    default: []
                   debug:
                     description: Whether or not activate the WP_DEBUG
                     type: boolean

--- a/wp-operator.py
+++ b/wp-operator.py
@@ -586,7 +586,7 @@ fastcgi_param WP_DB_PASSWORD     {secret};
       import_object = spec.get("epfl", {}).get("import")
       title = wordpress["title"]
       tagline = wordpress["tagline"]
-      plugins = wordpress["plugins"]
+      plugins = wordpress.get("plugins", [])
       languages = wordpress["languages"]
 
       self.create_database()


### PR DESCRIPTION
Avoid to have to set `plugins: []` in every CR that we define.