### PR TITLE
[feature](WPN-276) Create route only when necessary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,4 @@ COPY . .
 COPY --from=wp-base /wp /wp
 COPY --from=wp-base /usr/local/bin/wp /usr/local/bin/wp
 
-ENTRYPOINT [ "python3", "wp-operator.py", "run"]
+ENTRYPOINT [ "python3", "wp_operator.py", "run"]

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ help:
 operator:
 	python3 wp_operator.py run -n $(NAMESPACE)
 
+.PHONY: test
+test:
+	@python3 -m unittest discover -s test
+
 .PHONY: image
 ## Build, tag and push the image
 image: build push

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ help:
 .PHONY: operator
 ## Launch the WordPress operator (locally)
 operator:
-	python3 wp-operator.py run -n $(NAMESPACE)
+	python3 wp_operator.py run -n $(NAMESPACE)
 
 .PHONY: image
 ## Build, tag and push the image

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ To make it work on your device, follow these steps:
 1. Install all the dependencies using `pip install -r requirements.txt`
 1. If outside the EPFL network, check additional steps
 1. Run the operator using `make operator`
+1. Run unit tests using `make test`
 
 #### Additional steps
 

--- a/test/test_route_controller.py
+++ b/test/test_route_controller.py
@@ -1,0 +1,105 @@
+import unittest
+from wp_operator import RouteController
+
+
+class TestRouteController(unittest.TestCase):
+    def setUp(self):
+        self.controller = RouteController()
+        self.controller._routes_by_namespace = {
+            'namespace-test': {
+                'route_root': {
+                    'spec': {
+                        'host': 'www.example.com',
+                        'to': {'name': 'service1'}
+                    }
+                },
+                'route_foo': {
+                    'spec': {
+                        'host': 'www.example.com',
+                        'path': '/foo',
+                        'to': {'name': 'service2'}
+                    }
+                },
+                'route_foo_bar': {
+                    'spec': {
+                        'host': 'www.example.com',
+                        'path': '/foo/bar',
+                        'to': {'name': 'service3'}
+                    }
+                },
+                'route_foo_bar_sanka': {
+                    'spec': {
+                        'host': 'www.example.com',
+                        'path': '/foo/bar/sanka/',
+                        'to': {'name': 'service4'}
+                    }
+                }
+            }
+        }
+
+    def test_get_closest_parent_route_match_route_root(self):
+        result = self.controller._get_closest_parent_route('namespace-test', 'www.example.com', '/fooooo')
+        expected = {
+            'name': 'route_root',
+            'spec': {
+                'host': 'www.example.com',
+                'to': {'name': 'service1'}
+            }
+        }
+        self.assertEqual(result, expected)
+
+    def test_get_closest_parent_route_exact_match_route_foo(self):
+        result = self.controller._get_closest_parent_route('namespace-test', 'www.example.com', '/foo')
+        expected = {
+            'name': 'route_foo',
+            'spec': {
+                'host': 'www.example.com',
+                'path': '/foo',
+                'to': {'name': 'service2'}
+            }
+        }
+        self.assertEqual(result, expected)
+
+    def test_get_closest_parent_route_match_route_foo_bar(self):
+        result = self.controller._get_closest_parent_route('namespace-test', 'www.example.com', '/foo/bar/suomi')
+        expected = {
+            'name': 'route_foo_bar',
+            'spec': {
+                'host': 'www.example.com',
+                'path': '/foo/bar',
+                'to': {'name': 'service3'}
+            }
+        }
+        self.assertEqual(result, expected)
+
+    def test_get_closest_parent_route_match_route_foo_bar_sanka(self):
+        result = self.controller._get_closest_parent_route('namespace-test', 'www.example.com', '/foo/bar/sanka/cof')
+        expected = {
+            'name': 'route_foo_bar_sanka',
+            'spec': {
+                'host': 'www.example.com',
+                'path': '/foo/bar/sanka/',
+                'to': {'name': 'service4'}
+            }
+        }
+        self.assertEqual(result, expected)
+
+    def test_get_closest_parent_route_match_route_foo_bar_sanka_siteurl_with_final_slash(self):
+        result = self.controller._get_closest_parent_route('namespace-test', 'www.example.com', '/foo/bar/sanka/cof/')
+        expected = {
+            'name': 'route_foo_bar_sanka',
+            'spec': {
+                'host': 'www.example.com',
+                'path': '/foo/bar/sanka/',
+                'to': {'name': 'service4'}
+            }
+        }
+        self.assertEqual(result, expected)
+
+    def test_get_closest_parent_route_no_host_match(self):
+        result = self.controller._get_closest_parent_route('namespace-test', 'www.example.fi', '/foo/drebin')
+        self.assertIsNone(result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/wp_operator.py
+++ b/wp_operator.py
@@ -1,6 +1,6 @@
 # Kopf documentation : https://kopf.readthedocs.io/
 #
-# Run with `python3 wp-operator.py run --`
+# Run with `python3 wp_operator.py run --`
 #
 import argparse
 import base64
@@ -73,7 +73,7 @@ class Config:
     @classmethod
     def script_dir(cls):
         for arg in cls.saved_argv:
-            if "wp-operator.py" in arg:
+            if "wp_operator.py" in arg:
                 script_full_path = os.path.join(os.getcwd(), arg)
                 return os.path.dirname(script_full_path)
         return "."  # Take a guess
@@ -85,7 +85,7 @@ class Config:
     @classmethod
     def splice_our_argv(cls):
         if "--" in sys.argv:
-            # E.g.   python3 ./wp-operator.py run -n wordpress-toto -- --php=/usr/local/bin/php --wp-dir=yadda/yadda
+            # E.g.   python3 ./wp_operator.py run -n wordpress-toto -- --php=/usr/local/bin/php --wp-dir=yadda/yadda
             end_of_kopf = sys.argv.index("--")
             ret = sys.argv[end_of_kopf + 1:]
             sys.argv[end_of_kopf:] = []


### PR DESCRIPTION
Originally work → #28 
Partially roll-backed in https://github.com/epfl-si/wp-operator/commit/8b20b8b0eaa4dbd93721ea49c7432f2b38ad0dcf 

Note: I also renamed the file wp-operator.py to wp_operator.py, especially to support the import command in unit_tests.py.