### PR TITLE
[fix] Add s3 secrets as environment variables for mariadb restore

### DIFF
--- a/olm/Dockerfile.bundle
+++ b/olm/Dockerfile.bundle
@@ -26,7 +26,7 @@ COPY olm/controller-deployment-and-rbac.yaml \
      WordPressSite-crd.yaml \
      /bundle-gen
 
-ARG BUNDLE_VERSION=0.0.58
+ARG BUNDLE_VERSION=0.0.64
 
 RUN set -e -x; cd /bundle-gen; \
     sed -i 's|#\( *image\): controller:latest| \1: anonymous.apps.t-ocp-its-01.xaas.epfl.ch/svc0041/wordpress-olm-controller:v'"${BUNDLE_VERSION}"'|' controller-deployment-and-rbac.yaml; \

--- a/olm/Dockerfile.bundle
+++ b/olm/Dockerfile.bundle
@@ -26,7 +26,7 @@ COPY olm/controller-deployment-and-rbac.yaml \
      WordPressSite-crd.yaml \
      /bundle-gen
 
-ARG BUNDLE_VERSION=0.0.65
+ARG BUNDLE_VERSION=0.0.66
 
 RUN set -e -x; cd /bundle-gen; \
     sed -i 's|#\( *image\): controller:latest| \1: anonymous.apps.t-ocp-its-01.xaas.epfl.ch/svc0041/wordpress-olm-controller:v'"${BUNDLE_VERSION}"'|' controller-deployment-and-rbac.yaml; \

--- a/olm/Dockerfile.bundle
+++ b/olm/Dockerfile.bundle
@@ -26,7 +26,7 @@ COPY olm/controller-deployment-and-rbac.yaml \
      WordPressSite-crd.yaml \
      /bundle-gen
 
-ARG BUNDLE_VERSION=0.0.51
+ARG BUNDLE_VERSION=0.0.58
 
 RUN set -e -x; cd /bundle-gen; \
     sed -i 's|#\( *image\): controller:latest| \1: anonymous.apps.t-ocp-its-01.xaas.epfl.ch/svc0041/wordpress-olm-controller:v'"${BUNDLE_VERSION}"'|' controller-deployment-and-rbac.yaml; \

--- a/olm/Dockerfile.bundle
+++ b/olm/Dockerfile.bundle
@@ -26,7 +26,7 @@ COPY olm/controller-deployment-and-rbac.yaml \
      WordPressSite-crd.yaml \
      /bundle-gen
 
-ARG BUNDLE_VERSION=0.0.64
+ARG BUNDLE_VERSION=0.0.65
 
 RUN set -e -x; cd /bundle-gen; \
     sed -i 's|#\( *image\): controller:latest| \1: anonymous.apps.t-ocp-its-01.xaas.epfl.ch/svc0041/wordpress-olm-controller:v'"${BUNDLE_VERSION}"'|' controller-deployment-and-rbac.yaml; \

--- a/operator-namespaced.yaml
+++ b/operator-namespaced.yaml
@@ -113,43 +113,43 @@ spec:
           - --wp-dir=/wp/6
           - --secret-dir=/wp-secrets
           env:
-            - name: S3_DESTINATION_KEYID
-              valueFrom:
-                secretKeyRef:
-                  name: s3-credentials-for-os4
-                  key: keyId
-            - name: S3_DESTINATION_ACCESSSECRET
-              valueFrom:
-                secretKeyRef:
-                  name: s3-credentials-for-os4
-                  key: accessSecret
-            - name: EPFL_S3_SOURCE_KEYID
+            - name: S3_BACKUP_KEYID
               valueFrom:
                 secretKeyRef:
                   name: s3-backup-credentials
                   key: keyId
-            - name: EPFL_S3_SOURCE_ACCESSSECRET
+            - name: S3_BACKUP_ACCESSSECRET
               valueFrom:
                 secretKeyRef:
                   name: s3-backup-credentials
                   key: accessSecret
-            - name: EPFL_S3_SOURCE_BUCKET
+            - name: EPFL_S3_MIGRATION_KEYID
+              valueFrom:
+                secretKeyRef:
+                  name: epfl-s3-migrations-credentials
+                  key: keyId
+            - name: EPFL_S3_MIGRATION_ACCESSSECRET
+              valueFrom:
+                secretKeyRef:
+                  name: epfl-s3-migrations-credentials
+                  key: accessSecret
+            - name: EPFL_S3_MIGRATION_BUCKET
               valueFrom:
                 configMapKeyRef:
-                  name: s3-configmap-for-os3
+                  name: epfl-s3-migrations
                   key: s3_bucket_name
-            - name: S3_DESTINATION_BUCKET
+            - name: S3_BACKUP_BUCKET
               valueFrom:
                 configMapKeyRef:
-                  name: s3-configmap-for-os4
+                  name: wp-backups
                   key: s3_bucket_name
             - name: EPFL_RESTIC_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: restic-for-os3
+                  name: epfl-restic
                   key: resticPassword
-            - name: S3_DESTINATION_SECRETNAME
-              value: s3-credentials-for-os4
+            - name: S3_BACKUP_SECRETNAME
+              value: s3-backup-credentials
           volumeMounts:
             - name: wp-data
               mountPath: /wp-data/

--- a/operator-namespaced.yaml
+++ b/operator-namespaced.yaml
@@ -113,47 +113,42 @@ spec:
           - --wp-dir=/wp/6
           - --secret-dir=/wp-secrets
           env:
-            - name: s3-destination-keyId
+            - name: S3_DESTINATION_KEYID
               valueFrom:
                 secretKeyRef:
                   name: s3-credentials-for-os4
                   key: keyId
-            - name: s3-destination-accessSecret
+            - name: S3_DESTINATION_ACCESSSECRET
               valueFrom:
                 secretKeyRef:
                   name: s3-credentials-for-os4
                   key: accessSecret
-            - name: s3-source-keyId
+            - name: EPFL_S3_SOURCE_KEYID
               valueFrom:
                 secretKeyRef:
                   name: s3-backup-credentials
                   key: keyId
-            - name: s3-source-accessSecret
+            - name: EPFL_S3_SOURCE_ACCESSSECRET
               valueFrom:
                 secretKeyRef:
                   name: s3-backup-credentials
                   key: accessSecret
-            - name: s3-source-bucket
+            - name: EPFL_S3_SOURCE_BUCKET
               valueFrom:
                 configMapKeyRef:
                   name: s3-configmap-for-os3
                   key: s3_bucket_name
-            - name: s3-destination-bucket
+            - name: S3_DESTINATION_BUCKET
               valueFrom:
                 configMapKeyRef:
                   name: s3-configmap-for-os4
                   key: s3_bucket_name
-            - name: restic_secret
+            - name: EPFL_RESTIC_SECRET
               valueFrom:
                 secretKeyRef:
                   name: restic-for-os3
                   key: resticPassword
-            - name: restic_hostname
-              valueFrom:
-                secretKeyRef:
-                  name: restic-for-os3
-                  key: hostname
-            - name: s3-destination-secretName
+            - name: S3_DESTINATION_SECRETNAME
               value: s3-credentials-for-os4
           volumeMounts:
             - name: wp-data

--- a/operator-namespaced.yaml
+++ b/operator-namespaced.yaml
@@ -112,6 +112,13 @@ spec:
           - --
           - --wp-dir=/wp/6
           - --secret-dir=/wp-secrets
+          envFrom:
+            - configMapRef:
+                  name: epfl-migrations-s3
+            - configMapRef:
+                  name: wp-backups
+            - secretRef:
+                  name: epfl-migration-restic
           env:
             - name: S3_BACKUP_KEYID
               valueFrom:
@@ -123,31 +130,16 @@ spec:
                 secretKeyRef:
                   name: s3-backup-credentials
                   key: accessSecret
-            - name: EPFL_S3_MIGRATION_KEYID
+            - name: EPFL_MIGRATION_KEYID
               valueFrom:
                 secretKeyRef:
-                  name: epfl-s3-migrations-credentials
+                  name: epfl-migrations-s3-credentials
                   key: keyId
-            - name: EPFL_S3_MIGRATION_ACCESSSECRET
+            - name: EPFL_MIGRATION_ACCESSSECRET
               valueFrom:
                 secretKeyRef:
-                  name: epfl-s3-migrations-credentials
+                  name: epfl-migrations-s3-credentials
                   key: accessSecret
-            - name: EPFL_S3_MIGRATION_BUCKET
-              valueFrom:
-                configMapKeyRef:
-                  name: epfl-s3-migrations
-                  key: s3_bucket_name
-            - name: S3_BACKUP_BUCKET
-              valueFrom:
-                configMapKeyRef:
-                  name: wp-backups
-                  key: s3_bucket_name
-            - name: EPFL_RESTIC_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: epfl-restic
-                  key: resticPassword
             - name: S3_BACKUP_SECRETNAME
               value: s3-backup-credentials
           volumeMounts:

--- a/operator-namespaced.yaml
+++ b/operator-namespaced.yaml
@@ -112,12 +112,52 @@ spec:
           - --
           - --wp-dir=/wp/6
           - --secret-dir=/wp-secrets
-          - --restore-secrets-file=/restore-credentials/aws-cli-credentials.ini
+          env:
+            - name: s3-destination-keyId
+              valueFrom:
+                secretKeyRef:
+                  name: s3-credentials-for-os4
+                  key: keyId
+            - name: s3-destination-accessSecret
+              valueFrom:
+                secretKeyRef:
+                  name: s3-credentials-for-os4
+                  key: accessSecret
+            - name: s3-source-keyId
+              valueFrom:
+                secretKeyRef:
+                  name: s3-backup-credentials
+                  key: keyId
+            - name: s3-source-accessSecret
+              valueFrom:
+                secretKeyRef:
+                  name: s3-backup-credentials
+                  key: accessSecret
+            - name: s3-source-bucket
+              valueFrom:
+                configMapKeyRef:
+                  name: s3-configmap-for-os3
+                  key: s3_bucket_name
+            - name: s3-destination-bucket
+              valueFrom:
+                configMapKeyRef:
+                  name: s3-configmap-for-os4
+                  key: s3_bucket_name
+            - name: restic_secret
+              valueFrom:
+                secretKeyRef:
+                  name: restic-for-os3
+                  key: resticPassword
+            - name: restic_hostname
+              valueFrom:
+                secretKeyRef:
+                  name: restic-for-os3
+                  key: hostname
+            - name: s3-destination-secretName
+              value: s3-credentials-for-os4
           volumeMounts:
             - name: wp-data
               mountPath: /wp-data/
-            - name: restore-credentials
-              mountPath: /restore-credentials/
             - name: wp-data-ro-openshift3
               mountPath: /wp-data-ro-openshift3/
             - name: wp-secrets
@@ -137,9 +177,6 @@ spec:
         - name: wp-secrets
           secret:
             secretName: wp-plugin-secrets
-        - name: restore-credentials
-          secret:
-            secretName: restore-credentials
         - name: wp-data-ro-openshift3
           persistentVolumeClaim:
             claimName: wp-data-ro-openshift3

--- a/operator-namespaced.yaml
+++ b/operator-namespaced.yaml
@@ -114,11 +114,11 @@ spec:
           - --secret-dir=/wp-secrets
           envFrom:
             - configMapRef:
-                  name: epfl-migrations-s3
+                  name: epfl-migrations
             - configMapRef:
                   name: wp-backups
             - secretRef:
-                  name: epfl-migration-restic
+                  name: epfl-migrations
           env:
             - name: S3_BACKUP_KEYID
               valueFrom:
@@ -130,17 +130,8 @@ spec:
                 secretKeyRef:
                   name: s3-backup-credentials
                   key: accessSecret
-            - name: EPFL_MIGRATION_KEYID
-              valueFrom:
-                secretKeyRef:
-                  name: epfl-migrations-s3-credentials
-                  key: keyId
-            - name: EPFL_MIGRATION_ACCESSSECRET
-              valueFrom:
-                secretKeyRef:
-                  name: epfl-migrations-s3-credentials
-                  key: accessSecret
             - name: S3_BACKUP_SECRETNAME
+              # the operator need 'S3_BACKUP_SECRETNAME' so he can pass the secret to the MariaDB operator for initial restores
               value: s3-backup-credentials
           volumeMounts:
             - name: wp-data

--- a/wp_operator.py
+++ b/wp_operator.py
@@ -950,7 +950,7 @@ class NamespaceFromEnv:
     @classmethod
     def setup (cls):
         namespace = cls.get()
-        logging.info(f'WP-Operator v0.0.1 | codename: tippelskirchi')
+        logging.info(f'WP-Operator v1.0.0 | codename: camelopardalis')
         logging.info(f'Running in namespace {namespace}')
         os.environ['KUBERNETES_NAMESPACE'] = namespace
         try:

--- a/wp_operator.py
+++ b/wp_operator.py
@@ -738,10 +738,11 @@ class MigrationOperator:
       return self.spec.get('path')
 
   @property
-  def epfl_source_aws_credentials_env (self):
+  def epfl_restic_env (self):
       return {
           "AWS_SECRET_ACCESS_KEY": os.getenv("EPFL_MIGRATION_ACCESSSECRET"),
-          "AWS_ACCESS_KEY_ID": os.getenv("EPFL_MIGRATION_KEYID")
+          "AWS_ACCESS_KEY_ID": os.getenv("EPFL_MIGRATION_KEYID"),
+          "RESTIC_PASSWORD": os.getenv("RESTIC_PASSWORD")
       }
 
   @property
@@ -757,7 +758,7 @@ class MigrationOperator:
                         f"s3:https://s3.epfl.ch/{os.getenv('EPFL_MIGRATION_BUCKET')}/backup/wordpresses/{self.ansible_host}/sql",
                         "dump", "latest", "db-backup.sql"]
       logging.info(f"   Running: {' '.join(restic_command)}")
-      return subprocess.Popen(restic_command, env=self.epfl_source_aws_credentials_env,
+      return subprocess.Popen(restic_command, env=self.epfl_restic_env,
                                         stdout=subprocess.PIPE)
 
   def read_siteurl_from_sql_dump(self, restic_process_for_siteurl_stdout):

--- a/wp_operator.py
+++ b/wp_operator.py
@@ -771,7 +771,7 @@ class MigrationOperator:
           restic_process = subprocess.Popen(restic_command, env={**self.epfl_source_aws_credentials, **self.epfl_source_restic_credentials},
                                             stdout=subprocess.PIPE)
 
-          hostname_in_restic = os.getenv("restic_hostname")
+          hostname_in_restic = "www.epfl.ch"   # TODO: fix this
 
           sed_command = ["sed", "-e", rf"s/{re.escape(hostname_in_restic)}/{self.hostname}/g",
                          "-e",  rf"s/{re.escape(hostname_in_restic)}/{self.hostname}/g",

--- a/wp_operator.py
+++ b/wp_operator.py
@@ -774,7 +774,6 @@ class MigrationOperator:
           hostname_in_restic = "www.epfl.ch"   # TODO: fix this
 
           sed_command = ["sed", "-e", rf"s/{re.escape(hostname_in_restic)}/{self.hostname}/g",
-                         "-e",  rf"s/{re.escape(hostname_in_restic)}/{self.hostname}/g",
                          "-e",  rf"s|www.epfl.ch/campus/associations/list/|www.epfl.ch/campus/associations/|g",
                          ]
           logging.info(f"   Running: {' '.join(sed_command)}")

--- a/wp_operator.py
+++ b/wp_operator.py
@@ -740,15 +740,9 @@ class MigrationOperator:
   @property
   def epfl_source_aws_credentials(self):
       return {
-          "AWS_SECRET_ACCESS_KEY": os.getenv("EPFL_S3_MIGRATION_ACCESSSECRET"),
-          "AWS_ACCESS_KEY_ID": os.getenv("EPFL_S3_MIGRATION_KEYID"),
-          "BUCKET_NAME": os.getenv("EPFL_S3_MIGRATION_BUCKET")
-      }
-
-  @property
-  def epfl_source_restic_credentials(self):
-      return {
-          "RESTIC_PASSWORD": os.getenv("EPFL_RESTIC_SECRET")
+          "AWS_SECRET_ACCESS_KEY": os.getenv("EPFL_MIGRATION_ACCESSSECRET"),
+          "AWS_ACCESS_KEY_ID": os.getenv("EPFL_MIGRATION_KEYID"),
+          "BUCKET_NAME": os.getenv("EPFL_MIGRATION_BUCKET")
       }
 
   @property
@@ -765,7 +759,7 @@ class MigrationOperator:
                         f"s3:https://s3.epfl.ch/{self.epfl_source_aws_credentials['BUCKET_NAME']}/backup/wordpresses/{self.ansible_host}/sql",
                         "dump", "latest", "db-backup.sql"]
       logging.info(f"   Running: {' '.join(restic_command)}")
-      return subprocess.Popen(restic_command, env={**self.epfl_source_aws_credentials, **self.epfl_source_restic_credentials},
+      return subprocess.Popen(restic_command, env=self.epfl_source_aws_credentials,
                                         stdout=subprocess.PIPE)
 
   def read_siteurl_from_sql_dump(self, restic_process_for_siteurl_stdout):

--- a/wp_operator.py
+++ b/wp_operator.py
@@ -738,28 +738,26 @@ class MigrationOperator:
       return self.spec.get('path')
 
   @property
-  def epfl_source_aws_credentials(self):
+  def epfl_source_aws_credentials_env (self):
       return {
           "AWS_SECRET_ACCESS_KEY": os.getenv("EPFL_MIGRATION_ACCESSSECRET"),
-          "AWS_ACCESS_KEY_ID": os.getenv("EPFL_MIGRATION_KEYID"),
-          "BUCKET_NAME": os.getenv("EPFL_MIGRATION_BUCKET")
+          "AWS_ACCESS_KEY_ID": os.getenv("EPFL_MIGRATION_KEYID")
       }
 
   @property
-  def destination_credentials (self):
+  def destination_credentials_env (self):
       return {
           "AWS_SECRET_ACCESS_KEY": os.getenv("S3_BACKUP_ACCESSSECRET"),
-          "AWS_ACCESS_KEY_ID": os.getenv("S3_BACKUP_KEYID"),
-          "BUCKET_NAME": os.getenv("S3_BACKUP_BUCKET")
+          "AWS_ACCESS_KEY_ID": os.getenv("S3_BACKUP_KEYID")
       }
 
   def run_epfl_os3_restic(self):
       """Execute the Restic command to restore the backup"""
       restic_command = ["restic", "-r",
-                        f"s3:https://s3.epfl.ch/{self.epfl_source_aws_credentials['BUCKET_NAME']}/backup/wordpresses/{self.ansible_host}/sql",
+                        f"s3:https://s3.epfl.ch/{os.getenv('EPFL_MIGRATION_BUCKET')}/backup/wordpresses/{self.ansible_host}/sql",
                         "dump", "latest", "db-backup.sql"]
       logging.info(f"   Running: {' '.join(restic_command)}")
-      return subprocess.Popen(restic_command, env=self.epfl_source_aws_credentials,
+      return subprocess.Popen(restic_command, env=self.epfl_source_aws_credentials_env,
                                         stdout=subprocess.PIPE)
 
   def read_siteurl_from_sql_dump(self, restic_process_for_siteurl_stdout):
@@ -802,7 +800,7 @@ class MigrationOperator:
                           "s3", "cp", "-", s3_uri]
           logging.info(f"   Running: {' '.join(aws_command)}")
           aws_process = subprocess.Popen(aws_command,
-                                         env=self.destination_credentials,
+                                         env=self.destination_credentials_env,
                                          stdin=sed_process.stdout)
           sed_process.stdout.close()
 

--- a/wp_operator.py
+++ b/wp_operator.py
@@ -1,5 +1,15 @@
 # Kopf documentation : https://kopf.readthedocs.io/
 #
+# The operator consume the following environment variables:
+# S3_BACKUP_BUCKET: OpenShift 4' S3 bucket name used to paste the backup file for initial restores
+# S3_BACKUP_KEYID: S3 keyid
+# S3_BACKUP_ACCESSSECRET: S3 accessSecret
+# S3_BACKUP_SECRETNAME: OpenShift 4 secret name containing keyId and accessSecret.
+# The operator need 'S3_BACKUP_SECRETNAME' so he can pass the secret to the MariaDB operator for initial restores.
+# EPFL_MIGRATION_BUCKET: S3 bucket name for the old platform used to copy the backup file for initial restores
+# EPFL_MIGRATION_KEYID: S3 keyid for the old platform
+# EPFL_MIGRATION_ACCESSSECRET: S3 accesssecret for the old platform
+# RESTIC_PASSWORD: Extract the old platform's backup from EPFL_MIGRATION_BUCKET and copy the sql dump file into the S3_BACKUP_BUCKET
 # Run with `python3 wp_operator.py run --`
 #
 import argparse

--- a/wp_operator.py
+++ b/wp_operator.py
@@ -613,6 +613,7 @@ class WordPressSiteOperator:
           logging.info(f" ↳ [{self.namespace}/{self.name}] MariaDB object {mariadb_name} does not exist")
 
   def create_ingress(self, path, secret, hostname):
+    path_slash = ensure_final_slash(path)
     body = client.V1Ingress(
         api_version="networking.k8s.io/v1",
         kind="Ingress",
@@ -623,8 +624,8 @@ class WordPressSiteOperator:
             "nginx.ingress.kubernetes.io/configuration-snippet": f"""
 include "/etc/nginx/template/wordpress_fastcgi.conf";
 
-location = {path}/wp-admin {{
-    return 301 https://{hostname}{path}/wp-admin/;
+location = {path_slash}wp-admin {{
+    return 301 https://{hostname}{path_slash}wp-admin/;
 }}
 
 location ~ (wp-includes|wp-admin|wp-content/(plugins|mu-plugins|themes))/ {{
@@ -644,7 +645,7 @@ location ~ (wp-content/uploads)/ {{
 }}
 
 fastcgi_param WP_DEBUG           true;
-fastcgi_param WP_ROOT_URI        {ensure_final_slash(path)};
+fastcgi_param WP_ROOT_URI        {path_slash};
 fastcgi_param WP_SITE_NAME       {self.name};
 fastcgi_param WP_ABSPATH         /wp/6/;
 fastcgi_param WP_DB_HOST         {self.mariadb_name};


### PR DESCRIPTION
- New variables for backup "source" 
- New variables for backup "destination", used to restore the DB into OS4

Requires https://github.com/epfl-si/wp-ops/pull/621 for the updated secrets layout.