### PR TITLE
[fix] Set the `plugin:epfl_accred:subscriber_group` option to `*`

### DIFF
--- a/plugins/EPFLAccred.php
+++ b/plugins/EPFLAccred.php
@@ -4,6 +4,7 @@ class EPFLAccredPlugin extends Plugin
 {
   protected $pluginPath = "accred/EPFL-Accred.php";
   private $plugin_epfl_accred_administrator_group = "WP-SuperAdmin";
+  private $plugin_epfl_accred_subscriber_group = "*";
   private $plugin_epfl_accred_unit_id;
 
   function __construct($unit_id) {
@@ -13,6 +14,7 @@ class EPFLAccredPlugin extends Plugin
   public function updateOptions()
   {
     update_option( 'plugin:epfl_accred:administrator_group', $this->plugin_epfl_accred_administrator_group);
+    update_option( 'plugin:epfl_accred:subscriber_group', $this->plugin_epfl_accred_subscriber_group);
     update_option( 'plugin:epfl_accred:unit_id', $this->plugin_epfl_accred_unit_id);
   }
 }


### PR DESCRIPTION
When the plugin:epfl_accred:subscriber_group is not defined for an inside site, usera have an "Access denied" error