### PR TITLE
[feature] Allow fields update

### DIFF
--- a/WordPressSite-crd.yaml
+++ b/WordPressSite-crd.yaml
@@ -266,7 +266,6 @@ spec:
                   - title
                   - tagline
                   - theme
-                  - languages
               epfl:
                 description: WordpressSite's EPFL related specs
                 type: object
@@ -329,11 +328,6 @@ spec:
         type: string
         description: "WordPress site's unit"
         jsonPath: ".spec.owner.epfl.unitId"
-        priority: 1
-      - name: Languages
-        type: string
-        description: "Initial languages for the site"
-        jsonPath: ".spec.wordpress.languages"
         priority: 1
       - name: Plugins
         type: string

--- a/WordPressSite-crd.yaml
+++ b/WordPressSite-crd.yaml
@@ -230,10 +230,16 @@ spec:
                     description: WordpressSite's title
                     type: string
                     pattern: ^[\w\p{L}\p{M}\p{N}\p{P}\p{S}@._\- ]{1,}$
+                    x-kubernetes-validations:
+                      - message: Field 'wordpress.title' is immutable
+                        rule: self == oldSelf
                   tagline:
                     description: WordpressSite's tagline
                     type: string
                     pattern: ^[\w\p{L}\p{M}\p{N}\p{P}\p{S}@._\- ]{1,}$
+                    x-kubernetes-validations:
+                      - message: Field 'wordpress.tagline' is immutable
+                        rule: self == oldSelf
                   theme:
                     description: WordpressSite's theme
                     type: string

--- a/WordPressSite-crd.yaml
+++ b/WordPressSite-crd.yaml
@@ -241,15 +241,6 @@ spec:
                     x-kubernetes-validations:
                       - message: Field 'wordpress.theme' is immutable
                         rule: self == oldSelf
-                  languages:
-                    description: WordpressSite's languages
-                    type: array
-                    items:
-                      type: string
-                      pattern: ^[a-z]{2}$
-                    x-kubernetes-validations:
-                      - message: Field 'wordpress.language' is immutable
-                        rule: self == oldSelf
                   downloadsProtectionScript:
                     type: string
                     pattern: ^/(.*)

--- a/WordPressSite-crd.yaml
+++ b/WordPressSite-crd.yaml
@@ -221,9 +221,6 @@ spec:
                       unitId:
                         description: EPFL unit ID of the owner
                         type: integer
-                        x-kubernetes-validations:
-                          - message: Field 'owner.epfl.unitId' is immutable
-                            rule: self == oldSelf
                         # TODO : Obtain the “official” regex with ISCS-IAM team.
               wordpress:
                 description: WordpressSite's own specs
@@ -233,16 +230,10 @@ spec:
                     description: WordpressSite's title
                     type: string
                     pattern: ^[\w\p{L}\p{M}\p{N}\p{P}\p{S}@._\- ]{1,}$
-                    x-kubernetes-validations:
-                      - message: Field 'wordpress.title' is immutable
-                        rule: self == oldSelf
                   tagline:
                     description: WordpressSite's tagline
                     type: string
                     pattern: ^[\w\p{L}\p{M}\p{N}\p{P}\p{S}@._\- ]{1,}$
-                    x-kubernetes-validations:
-                      - message: Field 'wordpress.tagline' is immutable
-                        rule: self == oldSelf
                   theme:
                     description: WordpressSite's theme
                     type: string

--- a/ensure-wordpress-and-theme.php
+++ b/ensure-wordpress-and-theme.php
@@ -213,21 +213,6 @@ function generate_random_password(
   return $str;
 }
 
-function delete_footer_menus ()
-{
-    $pages = get_posts([
-        'post_type' => ['epfl-external-menu'],
-        'posts_per_page' => -1, // get all
-        'post_status' => array_keys(get_post_statuses()), // all post statuses (publish, draft, private etc...)
-    ]);
-
-    foreach ($pages as $page) {
-        if (strpos($page->post_title, 'Footer[') > -1 or strpos($page->post_title, 'Pied de page[') > -1) {
-            wp_delete_post($page->ID, true);
-        }
-    }
-}
-
 echo "DB schema\n";
 ensure_db_schema();
 echo "Options and common WordPress settings\n";

--- a/olm/Dockerfile.bundle
+++ b/olm/Dockerfile.bundle
@@ -27,7 +27,7 @@ COPY olm/controller-deployment-and-rbac.yaml \
      WordPressSite-crd.yaml \
      /bundle-gen
 
-ARG BUNDLE_VERSION=0.1.14
+ARG BUNDLE_VERSION=0.1.16
 
 RUN set -e -x; cd /bundle-gen; \
     sed -i 's|#\( *image\): controller:latest| \1: anonymous.apps.t-ocp-its-01.xaas.epfl.ch/svc0041/wordpress-olm-controller:v'"${BUNDLE_VERSION}"'|' controller-deployment-and-rbac.yaml; \

--- a/scripts/wps_patch_languages.js
+++ b/scripts/wps_patch_languages.js
@@ -30,19 +30,19 @@ async function makeFileExecutable() {
 }
 
 const LANGUAGES = [
-	{ name: "English", locale: "en_US", rtl: 0, term_group: 0, flag: "us", slug: "en_US" },
-	{ name: "English", locale: "en_GB", rtl: 0, term_group: 29, flag: "gb", slug: "en_GB" },
-	{ name: "Français", locale: "fr_FR", rtl: 0, term_group: 1, flag: "fr", slug: "fr_FR" },
-	{ name: "Deutsch", locale: "de_CH", rtl: 0, term_group: 20, flag: "ch", slug: "de_CH" },
-	{ name: "Deutsch", locale: "de_CH_informal", rtl: 0, term_group: 21, flag: "ch", slug: "de_CH_informal" },
-	{ name: "Deutsch", locale: "de_DE", rtl: 0, term_group: 22, flag: "de", slug: "de_DE" },
-	{ name: "Українська", locale: "uk", rtl: 0, term_group: 128, flag: "ua", slug: "uk" },
-	{ name: "Italiano", locale: "it_IT", rtl: 0, term_group: 3, flag: "it", slug: "it_IT" },
-	{ name: "Español", locale: "es_ES", rtl: 0, term_group: 4, flag: "es", slug: "es_ES" },
-	{ name: "Ελληνικά", locale: "el", rtl: 0, term_group: 5, flag: "gr", slug: "el" },
-	{ name: "Română", locale: "ro_RO", rtl: 0, term_group: 6, flag: "ro", slug: "ro_RO" },
-	{ name: "فارسی", locale: "fa_IR", rtl: 1, term_group: 50, flag: "ir", slug: "fa_IR" },
-	{ name: "Polski", locale: "pl_PL", rtl: 0, term_group: 97, flag: "pl", slug: "pl_PL" },
+	{ name: "English", locale: "en_US", rtl: 0, term_group: 0, flag: "us", slug: "en"},
+	{ name: "English", locale: "en_GB", rtl: 0, term_group: 29, flag: "gb", slug: "en"},
+	{ name: "Français", locale: "fr_FR", rtl: 0, term_group: 1, flag: "fr", slug: "fr"},
+	{ name: "Deutsch", locale: "de_CH", rtl: 0, term_group: 20, flag: "ch", slug: "de"},
+	{ name: "Deutsch", locale: "de_CH_informal", rtl: 0, term_group: 21, flag: "ch", slug: "de"},
+	{ name: "Deutsch", locale: "de_DE", rtl: 0, term_group: 22, flag: "de", slug: "de"},
+	{ name: "Українська", locale: "uk", rtl: 0, term_group: 128, flag: "ua", slug: "uk"},
+	{ name: "Italiano", locale: "it_IT", rtl: 0, term_group: 3, flag: "it", slug: "it"},
+	{ name: "Español", locale: "es_ES", rtl: 0, term_group: 4, flag: "es", slug: "es"},
+	{ name: "Ελληνικά", locale: "el", rtl: 0, term_group: 5, flag: "gr", slug: "el"},
+	{ name: "Română", locale: "ro_RO", rtl: 0, term_group: 6, flag: "ro", slug: "ro"},
+	{ name: "فارسی", locale: "fa_IR", rtl: 1, term_group: 50, flag: "ir", slug: "fa"},
+	{ name: "Polski", locale: "pl_PL", rtl: 0, term_group: 97, flag: "pl", slug: "pl"},
 ];
 
 const run = async () => {

--- a/scripts/wps_patch_languages.js
+++ b/scripts/wps_patch_languages.js
@@ -30,19 +30,19 @@ async function makeFileExecutable() {
 }
 
 const LANGUAGES = [
-	{ name: "English", locale: "en_US", rtl: 0, term_group: 0, flag: "us", slug: },
-	{ name: "English", locale: "en_GB", rtl: 0, term_group: 29, flag: "gb", slug: },
-	{ name: "Français", locale: "fr_FR", rtl: 0, term_group: 1, flag: "fr", slug: },
-	{ name: "Deutsch", locale: "de_CH", rtl: 0, term_group: 20, flag: "ch", slug: },
-	{ name: "Deutsch", locale: "de_CH_informal", rtl: 0, term_group: 21, flag: "ch", slug: },
-	{ name: "Deutsch", locale: "de_DE", rtl: 0, term_group: 22, flag: "de", slug: },
-	{ name: "Українська", locale: "uk", rtl: 0, term_group: 128, flag: "ua", slug: },
-	{ name: "Italiano", locale: "it_IT", rtl: 0, term_group: 3, flag: "it", slug: },
-	{ name: "Español", locale: "es_ES", rtl: 0, term_group: 4, flag: "es", slug: },
-	{ name: "Ελληνικά", locale: "el", rtl: 0, term_group: 5, flag: "gr", slug: },
-	{ name: "Română", locale: "ro_RO", rtl: 0, term_group: 6, flag: "ro", slug: },
-	{ name: "فارسی", locale: "fa_IR", rtl: 1, term_group: 50, flag: "ir", slug: },
-	{ name: "Polski", locale: "pl_PL", rtl: 0, term_group: 97, flag: "pl", slug: },
+	{ name: "English", locale: "en_US", rtl: 0, term_group: 0, flag: "us", slug: "en_US" },
+	{ name: "English", locale: "en_GB", rtl: 0, term_group: 29, flag: "gb", slug: "en_GB" },
+	{ name: "Français", locale: "fr_FR", rtl: 0, term_group: 1, flag: "fr", slug: "fr_FR" },
+	{ name: "Deutsch", locale: "de_CH", rtl: 0, term_group: 20, flag: "ch", slug: "de_CH" },
+	{ name: "Deutsch", locale: "de_CH_informal", rtl: 0, term_group: 21, flag: "ch", slug: "de_CH_informal" },
+	{ name: "Deutsch", locale: "de_DE", rtl: 0, term_group: 22, flag: "de", slug: "de_DE" },
+	{ name: "Українська", locale: "uk", rtl: 0, term_group: 128, flag: "ua", slug: "uk" },
+	{ name: "Italiano", locale: "it_IT", rtl: 0, term_group: 3, flag: "it", slug: "it_IT" },
+	{ name: "Español", locale: "es_ES", rtl: 0, term_group: 4, flag: "es", slug: "es_ES" },
+	{ name: "Ελληνικά", locale: "el", rtl: 0, term_group: 5, flag: "gr", slug: "el" },
+	{ name: "Română", locale: "ro_RO", rtl: 0, term_group: 6, flag: "ro", slug: "ro_RO" },
+	{ name: "فارسی", locale: "fa_IR", rtl: 1, term_group: 50, flag: "ir", slug: "fa_IR" },
+	{ name: "Polski", locale: "pl_PL", rtl: 0, term_group: 97, flag: "pl", slug: "pl_PL" },
 ];
 
 const run = async () => {

--- a/scripts/wps_patch_languages.js
+++ b/scripts/wps_patch_languages.js
@@ -1,0 +1,63 @@
+"use strict";
+const { promises: fs } = require("fs");
+const { exec } = require('child_process');
+
+const namespace = "wordpress-test";
+const patchFile = 'scripts/patchlanguages.sh';
+
+async function execKubectl(command) {
+	return new Promise((resolve, reject) => {
+		exec(command, (error, stdout, stderr) => {
+			if (error) {
+				reject(`Error executing command: ${error.message}`);
+				return;
+			}
+			if (stderr) {
+				reject(`Error output: ${stderr}`);
+				return;
+			}
+			resolve(JSON.parse(stdout));
+		});
+	});
+}
+
+async function write(content) {
+	await fs.writeFile(patchFile, content);
+}
+
+async function makeFileExecutable() {
+	await fs.chmod(patchFile, 0o755);
+}
+
+const LANGUAGES = [
+	{ name: "English", locale: "en_US", rtl: 0, term_group: 0, flag: "us", slug: },
+	{ name: "English", locale: "en_GB", rtl: 0, term_group: 29, flag: "gb", slug: },
+	{ name: "Français", locale: "fr_FR", rtl: 0, term_group: 1, flag: "fr", slug: },
+	{ name: "Deutsch", locale: "de_CH", rtl: 0, term_group: 20, flag: "ch", slug: },
+	{ name: "Deutsch", locale: "de_CH_informal", rtl: 0, term_group: 21, flag: "ch", slug: },
+	{ name: "Deutsch", locale: "de_DE", rtl: 0, term_group: 22, flag: "de", slug: },
+	{ name: "Українська", locale: "uk", rtl: 0, term_group: 128, flag: "ua", slug: },
+	{ name: "Italiano", locale: "it_IT", rtl: 0, term_group: 3, flag: "it", slug: },
+	{ name: "Español", locale: "es_ES", rtl: 0, term_group: 4, flag: "es", slug: },
+	{ name: "Ελληνικά", locale: "el", rtl: 0, term_group: 5, flag: "gr", slug: },
+	{ name: "Română", locale: "ro_RO", rtl: 0, term_group: 6, flag: "ro", slug: },
+	{ name: "فارسی", locale: "fa_IR", rtl: 1, term_group: 50, flag: "ir", slug: },
+	{ name: "Polski", locale: "pl_PL", rtl: 0, term_group: 97, flag: "pl", slug: },
+];
+
+const run = async () => {
+	const command = `kubectl get wps -n ${namespace} -o json | jq '[.items[] | {NAME: .metadata.name, languages: .status.wordpresssite.languages, polylang_spec: .spec.wordpress.plugins.polylang.polylang}]'`;
+	const wps = await execKubectl(command);
+	for (const site of wps) {
+		if (site["polylang_spec"] != null)
+			continue;
+		const languageList = []
+		site["languages"].forEach(l => {
+			languageList.push(LANGUAGES.find(lang => lang.locale == l))
+		})
+		await write(`kubectl patch wp ${site.NAME} -n ${namespace} --type='merge' -p '{"spec":{"wordpress": {"plugins": {"polylang": {"polylang": {"languages": ${JSON.stringify(languageList)}}}}}}}' \n`)
+		await makeFileExecutable();
+	}
+}
+
+run();

--- a/wp_operator.py
+++ b/wp_operator.py
@@ -958,7 +958,7 @@ class NamespaceFromEnv:
     @classmethod
     def setup (cls):
         namespace = cls.get()
-        logging.info(f'WP-Operator v2.1.0 | codename: Mellifera')
+        logging.info(f'WP-Operator v2.2.0 | codename: Mellifera')
         logging.info(f'Running in namespace {namespace}')
         os.environ['KUBERNETES_NAMESPACE'] = namespace
         try:

--- a/wp_operator.py
+++ b/wp_operator.py
@@ -325,7 +325,6 @@ class SiteReconcilerWork:
         self._php_work = ''
         self._plugins_to_activate = []
         self._plugins_to_deactivate = []
-        self._languages_to_delete = []
 
     def activate_plugin(self, plugin_name):
         self._plugins_to_activate.append(plugin_name)
@@ -339,7 +338,8 @@ class SiteReconcilerWork:
                          f'--rtl={lang["rtl"]}', f'--order={lang["term_group"]}', f'--flag={lang["flag"]}'])
 
     def delete_language(self, slug):
-        self._languages_to_delete.append(slug)
+        self.flush()
+        self._do_run_wp(['pll', 'lang', 'delete', f'{slug}'])
 
     def apply_sql(self, sql_filename):
         self.flush()
@@ -360,10 +360,6 @@ class SiteReconcilerWork:
         if self._plugins_to_deactivate:
             self._do_run_wp(['plugin', 'deactivate'] + self._plugins_to_deactivate)
         self._plugins_to_deactivate = []
-
-        if self._languages_to_delete:
-            self._do_run_wp(['pll', 'lang', 'delete'] + self._languages_to_delete)
-        self._languages_to_delete = []
 
         if self._php_work:
             self._do_run_wp(['eval', self._php_work])

--- a/wp_operator.py
+++ b/wp_operator.py
@@ -338,8 +338,8 @@ class SiteReconcilerWork:
         self._do_run_wp(['pll', 'lang', 'create', f'{lang["name"]}', f'{lang["slug"]}', f'{lang["locale"]}',
                          f'--rtl={lang["rtl"]}', f'--order={lang["term_group"]}', f'--flag={lang["flag"]}'])
 
-    def delete_language(self, locale):
-        self._languages_to_delete.append(locale)
+    def delete_language(self, slug):
+        self._languages_to_delete.append(slug)
 
     def apply_sql(self, sql_filename):
         self.flush()
@@ -722,23 +722,23 @@ class WordPressSiteOperator:
     plugins = wordpress.get("plugins", {})
     polylang = plugins.get("polylang", {}).get("polylang", {})
     languages_wanted = polylang.get("languages", [])
-    locale_wanted = {lang['locale'] for lang in languages_wanted}
+    slug_wanted = {lang['slug'] for lang in languages_wanted}
 
     status_spec = status.get("wordpresssite", {})
     languages_got = status_spec.get("languages", [])
-    locale_got = {lang for lang in languages_got}
+    slug_got = {lang for lang in languages_got}
 
-    languages_to_activate = locale_wanted - locale_got
+    languages_to_activate = slug_wanted - slug_got
     logging.info(f'languages_to_activate: {languages_to_activate}')
-    for locale in languages_to_activate:
-        language = next((lang for lang in languages_wanted if lang["locale"] == locale), None)
+    for slug in languages_to_activate:
+        language = next((lang for lang in languages_wanted if lang["slug"] == slug), None)
         if language:
             work.add_language(language)
 
-    languages_to_deactivate = locale_got - locale_wanted
+    languages_to_deactivate = slug_got - slug_wanted
     logging.info(f'languages_to_deactivate: {languages_to_deactivate}')
-    for locale in languages_to_deactivate:
-        work.delete_language(locale)
+    for slug in languages_to_deactivate:
+        work.delete_language(slug)
 
     work.flush()
     logging.info(f"End of reconcile WordPressSite languages {self.name=} in {self.namespace=}")
@@ -775,7 +775,7 @@ class WordPressSiteOperator:
 
   def _status_wordpresssite_struct(self):
       if 'DEBUG' in os.environ:
-          out = {'plugins': {'tata': {}, 'titi': {}}}
+          out = {}
       else:
           cmdline = ['wp', f'--ingress={self.ingress_name}', 'eval', '''echo(json_encode(apply_filters('wp_operator_status',[]), JSON_PRETTY_PRINT));''']
           result = self._do_run_wp(cmdline, capture_output=True, text=True)
@@ -959,7 +959,7 @@ class NamespaceFromEnv:
     @classmethod
     def setup (cls):
         namespace = cls.get()
-        logging.info(f'WP-Operator v2.1.0 | codename: Chihuahua')
+        logging.info(f'WP-Operator v2.1.0 | codename: Mellifera')
         logging.info(f'Running in namespace {namespace}')
         os.environ['KUBERNETES_NAMESPACE'] = namespace
         try:

--- a/wp_operator.py
+++ b/wp_operator.py
@@ -726,7 +726,7 @@ class WordPressSiteOperator:
 
     status_spec = status.get("wordpresssite", {})
     languages_got = status_spec.get("languages", [])
-    locale_got = {lang['locale'] for lang in languages_got}
+    locale_got = {lang for lang in languages_got}
 
     languages_to_activate = locale_wanted - locale_got
     logging.info(f'languages_to_activate: {languages_to_activate}')

--- a/wp_operator.py
+++ b/wp_operator.py
@@ -746,6 +746,7 @@ class WordPressSiteOperator:
       work = SiteReconcilerWork(self)
       unit = spec.get("owner", {}).get("epfl", {}).get("unitId", {})
       work.set_wp_option('plugin:epfl_accred:unit_id', unit)
+      work.flush()
       logging.info(f"Reconcile WordPressSite unit_id {self.name=} in {self.namespace=}")
 
   def _patch_wordpresssite_status (self):


### PR DESCRIPTION
- Remove useless `language` field from CRD. It is now inside the polylang plugin.
- make `unitId` mutable
- Remove deadcode: `delete_footer_menus` function was used for restore
- Upgrade bundle version to 0.1.16
- Upgrade operator version to 2.2.0:Mellifera
- Add scripts/wps_patch_languages.js to patch existing CR specs with languages from status
- Trigger operator when status.languages changes
- Trigger operator when status.unitId changes
- reconcile wordpresssite for languages and unitid