### PR TITLE
[unfeature] `/wp/6`, part deux

### DIFF
--- a/operator-namespaced.yaml
+++ b/operator-namespaced.yaml
@@ -112,7 +112,7 @@ spec:
           args:
           - --namespace=wordpress-test
           - --
-          - --wp-dir=/wp/6
+          - --wp-dir=/wp
           - --secret-dir=/wp-secrets
           envFrom:
             - configMapRef:


### PR DESCRIPTION
Follow-up to #57 with some leftover `/wp/6`